### PR TITLE
Fix resolution issue

### DIFF
--- a/osu!stream/Director.cs
+++ b/osu!stream/Director.cs
@@ -240,6 +240,8 @@ namespace osum
             }
 
             PendingMode = mode;
+            
+            GameBase.Instance.SetViewport();
         }
 
         private static bool modeChangePending;

--- a/osu!stream/Support/Android/GameBaseAndroid.cs
+++ b/osu!stream/Support/Android/GameBaseAndroid.cs
@@ -76,7 +76,7 @@ namespace osum
         public override void SetupScreen()
         {
             // Because this is always landscape, we'll use the safe width and real height of the display.
-            NativeSize = new System.Drawing.Size(_activity.Resources.DisplayMetrics.WidthPixels, (int)DeviceDisplay.MainDisplayInfo.Height);
+            NativeSize = new System.Drawing.Size((int)DeviceDisplay.MainDisplayInfo.Width, (int)DeviceDisplay.MainDisplayInfo.Height);
 
             base.SetupScreen();
         }


### PR DESCRIPTION
 all i need to do is get the display to render on the left side of the screen then it should be good, as rn it seems to render weirdly when it comes to display cutouts, i cant get it to render inside the cutout
 
 EDIT: heres some clarifications on the issue, i have the `LayoutInDisplayCutoutMode` set to `ShortEdges` so it should be rendering in the cutout, but something else is forcing it to render next to the cutout rather then inside, which casuse the right side of the screen to get cut off